### PR TITLE
feat: enhance error handling for package name validation

### DIFF
--- a/tooling/nargo_cli/src/cli/init_cmd.rs
+++ b/tooling/nargo_cli/src/cli/init_cmd.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Args)]
 pub(crate) struct InitCommand {
     /// Name of the package [default: current directory name]
-    #[clap(long)]
+    #[clap(index = 1)]
     name: Option<CrateName>,
 
     /// Use a library template
@@ -36,8 +36,11 @@ pub(crate) fn run(args: InitCommand, config: NargoConfig) -> Result<(), CliError
     let package_name = match args.name {
         Some(name) => name,
         None => {
-            let name = config.program_dir.file_name().unwrap().to_str().unwrap();
-            name.parse().map_err(|_| CliError::InvalidPackageName(name.into()))?
+            let name_str = config.program_dir.file_name().unwrap().to_str().unwrap();
+            name_str.parse().map_err(|e| CliError::InvalidPackageNameFromDirectory {
+                directory_name: name_str.to_string(),
+                parse_error: e.to_string(),
+            })?
         }
     };
 

--- a/tooling/nargo_cli/src/errors.rs
+++ b/tooling/nargo_cli/src/errors.rs
@@ -17,6 +17,9 @@ pub enum CliError {
     #[error("Invalid package name {0}. Did you mean to use `--name`?")]
     InvalidPackageName(String),
 
+    #[error("The current directory name '{directory_name}' is not a valid package name. Reason: {parse_error}. Please provide a name explicitly: nargo init <package_name>")]
+    InvalidPackageNameFromDirectory { directory_name: String, parse_error: String },
+
     #[error("`--debug-compile-stdin` is incompatible with `--watch`")]
     CantWatchStdin,
 


### PR DESCRIPTION
Added a new error variant `InvalidPackageNameFromDirectory` to provide clearer feedback when the current directory name is not a valid package name. Updated the `InitCommand` to utilize this new error for improved user guidance during initialization.

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
